### PR TITLE
getContextTitle() can throw a runtime exception

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -67,7 +67,11 @@ class Hooks implements
 	 * @throws ErrorPageError
 	 */
 	public function onEditPage__showEditForm_initial( $editpage, $output ) {
-		$title = $editpage->getContextTitle();
+		try {
+			$title = $editpage->getContextTitle();
+		} catch (\RuntimeException) {
+			$title = $editpage->getTitle();
+		}
 		$model = $editpage->contentModel;
 		$format = $editpage->contentFormat;
 


### PR DESCRIPTION
This happens for example when using the preview feature on a PageForms form.